### PR TITLE
4 player splitscreen support

### DIFF
--- a/SplitScreenCoop/SplitScreenCoop.CoopFixes.cs
+++ b/SplitScreenCoop/SplitScreenCoop.CoopFixes.cs
@@ -164,6 +164,8 @@ namespace SplitScreenCoop
         private void RoomCamera_ChangeCameraToPlayer(On.RoomCamera.orig_ChangeCameraToPlayer orig, RoomCamera self, AbstractCreature cameraTarget)
         {
             Logger.LogInfo("RoomCamera_ChangeCameraToPlayer");
+            if (CurrentSplitMode == SplitMode.Split4Screen) // prevent camera switching
+                return;
             if (cameraTarget.realizedCreature is Player player)
             {
                 AssignCameraToPlayer(self, player);

--- a/SplitScreenCoop/SplitScreenCoop.Multicamera.cs
+++ b/SplitScreenCoop/SplitScreenCoop.Multicamera.cs
@@ -414,11 +414,7 @@ namespace SplitScreenCoop
                     c.Emit(OpCodes.Ldarg_0); // RoomCamera
                     c.EmitDelegate<Func<float, RoomCamera, float>>((v, rc) =>
                     {
-                        if (CurrentSplitMode == SplitMode.SplitHorizontal)
-                        {
-                            return v + rc.sSize.y / 4f;
-                        }
-                        else if (CurrentSplitMode == SplitMode.Split4Screen)
+                        if (CurrentSplitMode == SplitMode.SplitHorizontal || CurrentSplitMode == SplitMode.Split4Screen)
                         {
                             return v - rc.sSize.y / 4f;
                         }
@@ -519,11 +515,7 @@ namespace SplitScreenCoop
                         c.Emit(OpCodes.Ldarg_0); // RoomCamera
                         c.EmitDelegate<Func<float, RoomCamera, float>>((v, rc) =>
                         {
-                            if (CurrentSplitMode == SplitMode.SplitHorizontal)
-                            {
-                                return v + rc.sSize.y / 4f;
-                            }
-                            else if (CurrentSplitMode == SplitMode.Split4Screen)
+                            if (CurrentSplitMode == SplitMode.SplitHorizontal || CurrentSplitMode == SplitMode.Split4Screen)
                             {
                                 return v - rc.sSize.y / 4f;
                             }

--- a/SplitScreenCoop/SplitScreenCoop.Multicamera.cs
+++ b/SplitScreenCoop/SplitScreenCoop.Multicamera.cs
@@ -328,6 +328,30 @@ namespace SplitScreenCoop
                             rc.pos.x += rc.followCreatureInputForward.x * 2f;
                         }
                     }
+                    else if(CurrentSplitMode == SplitMode.Split4Screen)
+                    {
+                        float pad = rc.sSize.x / 4f;
+                        float pad2 = rc.sSize.y / 4f;
+                        if (rc.followAbstractCreature != null && rc.followAbstractCreature.realizedCreature is Creature cr)
+                        {
+                            if (!cr.inShortcut)
+                            {
+                                rc.pos.x = rc.followAbstractCreature.realizedCreature.mainBodyChunk.pos.x - 2 * pad;
+                                rc.pos.y = rc.followAbstractCreature.realizedCreature.mainBodyChunk.pos.y - 2 * pad2;
+                            }
+                            else
+                            {
+                                Vector2? vector = rc.room.game.shortcuts.OnScreenPositionOfInShortCutCreature(rc.room, cr);
+                                if (vector != null)
+                                {
+                                    rc.pos.x = vector.Value.x - 2 * pad;
+                                    rc.pos.y = vector.Value.y - 2 * pad2;
+                                }
+                            }
+                            rc.pos.x += rc.followCreatureInputForward.x * 2f;
+                            rc.pos.y += rc.followCreatureInputForward.y * 2f;
+                        }
+                    }
                 });
 
                 try
@@ -337,7 +361,7 @@ namespace SplitScreenCoop
                     c.Emit(OpCodes.Ldarg_0); // RoomCamera
                     c.EmitDelegate<Func<float, RoomCamera, float>>((v, rc) =>
                     {
-                        if (CurrentSplitMode == SplitMode.SplitVertical)
+                        if (CurrentSplitMode == SplitMode.SplitVertical || CurrentSplitMode == SplitMode.Split4Screen)
                         {
                             return v - rc.sSize.x / 4f;
                         }
@@ -349,7 +373,7 @@ namespace SplitScreenCoop
                     c.Emit(OpCodes.Ldarg_0); // RoomCamera
                     c.EmitDelegate<Func<float, RoomCamera, float>>((v, rc) =>
                     {
-                        if (CurrentSplitMode == SplitMode.SplitVertical)
+                        if (CurrentSplitMode == SplitMode.SplitVertical || CurrentSplitMode == SplitMode.Split4Screen)
                         {
                             return v + rc.sSize.x / 4f;
                         }
@@ -365,6 +389,10 @@ namespace SplitScreenCoop
                         {
                             return v + rc.sSize.y / 4f;
                         }
+                        else if (CurrentSplitMode == SplitMode.Split4Screen)
+                        {
+                            return v - rc.sSize.y / 4f;
+                        }
                         return v;
                     });
 
@@ -374,7 +402,7 @@ namespace SplitScreenCoop
                     c.Emit(OpCodes.Ldarg_0); // RoomCamera
                     c.EmitDelegate<Func<float, RoomCamera, float>>((v, rc) =>
                     {
-                        if (CurrentSplitMode == SplitMode.SplitHorizontal)
+                        if (CurrentSplitMode == SplitMode.SplitHorizontal || CurrentSplitMode == SplitMode.Split4Screen)
                         {
                             return v + rc.sSize.y / 4f;
                         }
@@ -438,7 +466,7 @@ namespace SplitScreenCoop
                         c.Emit(OpCodes.Ldarg_0); // RoomCamera
                         c.EmitDelegate<Func<float, RoomCamera, float>>((v, rc) =>
                         {
-                            if (CurrentSplitMode == SplitMode.SplitVertical)
+                            if (CurrentSplitMode == SplitMode.SplitVertical || CurrentSplitMode == SplitMode.Split4Screen)
                             {
                                 return v - rc.sSize.x / 4f;
                             }
@@ -450,7 +478,7 @@ namespace SplitScreenCoop
                         c.Emit(OpCodes.Ldarg_0); // RoomCamera
                         c.EmitDelegate<Func<float, RoomCamera, float>>((v, rc) =>
                         {
-                            if (CurrentSplitMode == SplitMode.SplitVertical)
+                            if (CurrentSplitMode == SplitMode.SplitVertical || CurrentSplitMode == SplitMode.Split4Screen)
                             {
                                 return v + rc.sSize.x / 4f;
                             }
@@ -466,6 +494,10 @@ namespace SplitScreenCoop
                             {
                                 return v + rc.sSize.y / 4f;
                             }
+                            else if (CurrentSplitMode == SplitMode.Split4Screen)
+                            {
+                                return v - rc.sSize.y / 4f;
+                            }
                             return v;
                         });
 
@@ -475,7 +507,7 @@ namespace SplitScreenCoop
                         c.Emit(OpCodes.Ldarg_0); // RoomCamera
                         c.EmitDelegate<Func<float, RoomCamera, float>>((v, rc) =>
                         {
-                            if (CurrentSplitMode == SplitMode.SplitHorizontal)
+                            if (CurrentSplitMode == SplitMode.SplitHorizontal || CurrentSplitMode == SplitMode.Split4Screen)
                             {
                                 return v + rc.sSize.y / 4f;
                             }

--- a/SplitScreenCoop/SplitScreenCoop.Multicamera.cs
+++ b/SplitScreenCoop/SplitScreenCoop.Multicamera.cs
@@ -131,9 +131,14 @@ namespace SplitScreenCoop
         {
             if (gm.owner.room.game.cameras.Length > 1)
             {
-                return orig(gm) &&
-                !gm.owner.room.game.cameras[1].PositionCurrentlyVisible(gm.owner.firstChunk.pos, gm.cullRange + ((!gm.culled) ? 100f : 0f), true) &&
-                !gm.owner.room.game.cameras[1].PositionVisibleInNextScreen(gm.owner.firstChunk.pos, (!gm.culled) ? 100f : 50f, true);
+                bool result = orig(gm);
+                for (int i = 1; i < gm.owner.room.game.session.Players.Count; i++)
+                {
+                    result = result &&
+                    !gm.owner.room.game.cameras[i].PositionCurrentlyVisible(gm.owner.firstChunk.pos, gm.cullRange + ((!gm.culled) ? 100f : 0f), true) &&
+                    !gm.owner.room.game.cameras[i].PositionVisibleInNextScreen(gm.owner.firstChunk.pos, (!gm.culled) ? 100f : 50f, true);
+                }
+                return result;
             }
             return orig(gm);
         }

--- a/SplitScreenCoop/SplitScreenCoop.Multicamera.cs
+++ b/SplitScreenCoop/SplitScreenCoop.Multicamera.cs
@@ -97,6 +97,7 @@ namespace SplitScreenCoop
         {
             orig(self, player);
             OffsetHud(self);
+            AssignCameraToPlayer(self, (Player)self.game.session.Players[self.cameraNumber].realizedCreature);
         }
 
         public delegate bool delget_ShouldBeCulled(GraphicsModule gm);

--- a/SplitScreenCoop/SplitScreenCoop.Multicamera.cs
+++ b/SplitScreenCoop/SplitScreenCoop.Multicamera.cs
@@ -77,6 +77,29 @@ namespace SplitScreenCoop
                         inpause = false;
                     }
                 }
+                else if (CurrentSplitMode == SplitMode.Split4Screen)
+                {
+                    float xOffset = manager.rainWorld.screenSize.x / 4f;
+                    float yOffset = manager.rainWorld.screenSize.y / 4f;
+                    self.container.SetPosition(xOffset, -yOffset);
+                    inpause = true;
+                    try
+                    {
+                        var pause2 = new Menu.PauseMenu(manager, game);
+                        var pause3 = new Menu.PauseMenu(manager, game);
+                        var pause4 = new Menu.PauseMenu(manager, game);
+                        pause2.container.SetPosition(camOffsets[game.cameras[1].cameraNumber] + new Vector2(-xOffset, -yOffset));
+                        pause3.container.SetPosition(camOffsets[game.cameras[2].cameraNumber] + new Vector2(xOffset, yOffset));
+                        pause4.container.SetPosition(camOffsets[game.cameras[3].cameraNumber] + new Vector2(-xOffset, yOffset));
+                        manager.sideProcesses.Add(pause2);
+                        manager.sideProcesses.Add(pause3);
+                        manager.sideProcesses.Add(pause4);
+                    }
+                    finally
+                    {
+                        inpause = false;
+                    }
+                }
             }
         }
 

--- a/SplitScreenCoop/SplitScreenCoop.cs
+++ b/SplitScreenCoop/SplitScreenCoop.cs
@@ -95,14 +95,6 @@ namespace SplitScreenCoop
                 if (CurrentSplitMode != SplitMode.NoSplit && GameObject.FindObjectOfType<RainWorld>()?.processManager?.currentMainLoop is RainWorldGame game)
                     SetSplitMode(preferedSplitMode, game);
             }
-            if (Input.GetKeyDown("f9"))
-            {
-                RainWorldGame game = (RainWorldGame)GameObject.FindObjectOfType<RainWorld>()?.processManager?.currentMainLoop;
-                CurrentSplitMode = preferedSplitMode = SplitMode.Split4Screen;
-                SetSplitMode(preferedSplitMode, game);
-                for (int i = 0; i < game.session.Players.Count; i++)
-                    AssignCameraToPlayer(game.cameras[i], (Player)game.session.Players[i].realizedCreature);
-            }
         }
 
         public void OnModsInit(On.RainWorld.orig_OnModsInit orig, RainWorld self)

--- a/SplitScreenCoop/SplitScreenCoop.cs
+++ b/SplitScreenCoop/SplitScreenCoop.cs
@@ -56,6 +56,7 @@ namespace SplitScreenCoop
             NoSplit,
             SplitHorizontal, // top bottom screens
             SplitVertical, // left right screens
+            Split4Screen // 4 players
         }
 
         public static SplitMode CurrentSplitMode;
@@ -96,6 +97,8 @@ namespace SplitScreenCoop
             if (Input.GetKeyDown("f9"))
             {
                 RainWorldGame game = (RainWorldGame)GameObject.FindObjectOfType<RainWorld>()?.processManager?.currentMainLoop;
+                CurrentSplitMode = preferedSplitMode = SplitMode.Split4Screen;
+                SetSplitMode(preferedSplitMode, game);
                 for (int i = 0; i < game.session.Players.Count; i++)
                     AssignCameraToPlayer(game.cameras[i], (Player)game.session.Players[i].realizedCreature);
             }
@@ -508,8 +511,16 @@ namespace SplitScreenCoop
                             cameraListeners[1].direct = false;
                             cameraListeners[1].SetMap(new Rect(0f, 0.25f, 1f, 0.5f), new Rect(0f, 0f, 1f, 0.5f));
                             break;
-                        default:
+                        case SplitMode.SplitVertical:
                             Logger.LogInfo("SplitVertical");
+                            cameraListeners[0].direct = false;
+                            cameraListeners[0].SetMap(new Rect(0.25f, 0f, 0.5f, 1f), new Rect(0f, 0f, 0.5f, 1f));
+                            fcameras[1].enabled = true;
+                            cameraListeners[1].direct = false;
+                            cameraListeners[1].SetMap(new Rect(0.25f, 0f, 0.5f, 1f), new Rect(0.5f, 0f, 0.5f, 1f));
+                            break;
+                        case SplitMode.Split4Screen:
+                            Logger.LogInfo("Split4Screen");
                             cameraListeners[0].direct = false;
                             cameraListeners[0].SetMap(new Rect(0.25f, 0.25f, 0.5f, 0.5f), new Rect(0f, 0.5f, 0.5f, 0.5f));
                             fcameras[1].enabled = true;
@@ -521,6 +532,8 @@ namespace SplitScreenCoop
                             fcameras[3].enabled = true;
                             cameraListeners[3].direct = false;
                             cameraListeners[3].SetMap(new Rect(0.25f, 0.25f, 0.5f, 0.5f), new Rect(0.5f, 0f, 0.5f, 0.5f));
+                            break;
+                        default:
                             break;
                     }
                 }
@@ -594,6 +607,10 @@ namespace SplitScreenCoop
                 offset += new Vector2(0, self.sSize.y / 4f);
             }
             else if(CurrentSplitMode == SplitMode.SplitVertical)
+            {
+                offset += new Vector2(self.sSize.x / 4f, 0f);
+            }
+            else if(CurrentSplitMode == SplitMode.Split4Screen)
             {
                 offset += new Vector2(self.sSize.x / 4f, self.sSize.y / 4f);
             }

--- a/SplitScreenCoop/SplitScreenCoop.cs
+++ b/SplitScreenCoop/SplitScreenCoop.cs
@@ -639,9 +639,7 @@ namespace SplitScreenCoop
             {
                 offset += new Vector2(self.sSize.x / 4f, self.sSize.y / 4f);
             }
-            self.ReturnFContainer("HUD").SetPosition(offset);
             self.ReturnFContainer("HUD2").SetPosition(offset);
-            self.hud?.map?.inFrontContainer?.SetPosition(offset);
         }
     }
 }

--- a/SplitScreenCoop/SplitScreenCoop.cs
+++ b/SplitScreenCoop/SplitScreenCoop.cs
@@ -339,14 +339,13 @@ namespace SplitScreenCoop
                         var cams = self.cameras;
                         Array.Resize(ref cams, 4);
                         self.cameras = cams;
-                        cams[1] = new RoomCamera(self, 1);
-                        cams[2] = new RoomCamera(self, 2);
-                        cams[3] = new RoomCamera(self, 3);
-
+                        for(int i = 1; i < 4; i++)
+                        {
+                            cams[i] = new RoomCamera(self, i);
+                            if(self.session.Players.Count > i)
+                                cams[i].followAbstractCreature = self.session.Players[i];
+                        }
                         cams[0].followAbstractCreature = self.session.Players[0];
-                        cams[1].followAbstractCreature = self.session.Players[1];
-                        cams[2].followAbstractCreature = self.session.Players[2];
-                        cams[3].followAbstractCreature = self.session.Players[3];
                     }
                     Logger.LogInfo("RainWorldGame_ctor1 hookpoint done");
                 });
@@ -375,13 +374,11 @@ namespace SplitScreenCoop
             if (self.cameras.Length > 1)
             {
                 Logger.LogInfo("camera2 detected");
-                self.cameras[1].MoveCamera(self.world.activeRooms[0], 0);
-                self.cameras[2].MoveCamera(self.world.activeRooms[0], 0);
-                self.cameras[3].MoveCamera(self.world.activeRooms[0], 0);
-                self.cameras[0].followAbstractCreature = self.session.Players[0];
-                self.cameras[1].followAbstractCreature = self.session.Players[1];
-                self.cameras[2].followAbstractCreature = self.session.Players[2];
-                self.cameras[3].followAbstractCreature = self.session.Players[3];
+                for(int i = 1; i < self.session.Players.Count; i++)
+                {
+                    self.cameras[i].MoveCamera(self.world.activeRooms[0], 0);
+                    self.cameras[i].followAbstractCreature = self.session.Players[i];
+                }
                 SetSplitMode(alwaysSplit ? preferedSplitMode : SplitMode.NoSplit, self);
             }
             else
@@ -476,13 +473,9 @@ namespace SplitScreenCoop
             if (game.cameras.Length > 1)
             {
                 Logger.LogInfo("multicam");
-                var main = game.cameras[0];
-                var other = game.cameras[1];
                 CurrentSplitMode = split;
-                OffsetHud(main);
-                OffsetHud(other);
-                OffsetHud(game.cameras[2]);
-                OffsetHud(game.cameras[3]);
+                for(int i = 0; i < game.cameras.Length; i++)
+                    OffsetHud(game.cameras[i]);
 
                 if (dualDisplays)
                 {

--- a/SplitScreenCoop/SplitScreenCoop.cs
+++ b/SplitScreenCoop/SplitScreenCoop.cs
@@ -619,6 +619,8 @@ namespace SplitScreenCoop
         public void OffsetHud(RoomCamera self)
         {
             Vector2 offset = camOffsets[self.cameraNumber];
+            self.hud?.map?.inFrontContainer?.SetPosition(offset); // map icons
+
             if (CurrentSplitMode == SplitMode.SplitHorizontal)
             {
                 offset += new Vector2(0, self.sSize.y / 4f);
@@ -631,7 +633,7 @@ namespace SplitScreenCoop
             {
                 offset += new Vector2(self.sSize.x / 4f, self.sSize.y / 4f);
             }
-            self.ReturnFContainer("HUD2").SetPosition(offset);
+            self.ReturnFContainer("HUD2").SetPosition(offset); // rain/karma/food
         }
     }
 }


### PR DESCRIPTION
Players on screen in this order:
1 2
3 4

![4slugs](https://github.com/henpemaz/RemixMods/assets/5028587/f4439640-9b32-4b27-94d0-fea42c2b8237)

TODO:
- [x] Make the hook for changing texture array size. Change `this.cameraTextures = new Texture2D[2, 2];` in `PersistentData` constructor and also change loop bounds there
- [x] Currently it replaces vertical split mode and requires Always split to be on. Move 4 screen mode into a separate thing?
- [x] Camera not following players until the very corners of the screen
 - [x] Players aren't followed by cameras correctly when you enter the game for some reason (I temporarily added f9 button doing that manually)
- [x] Looking at the map is partly broken
- [x] Pause menu is misaligned
- [x] Jolly Coop related hud is misaligned
- [ ] Does shader stuff need to be updated?
- [ ] Does realizer stuff need to be updated?
- [ ] Does anything else need to be updated?
- [ ] Maybe tapping map button zooms out/in camera on specific player screen?