### PR TITLE
Zoom 4 split screen feature plus some bug fixes

### DIFF
--- a/SplitScreenCoop/SplitScreenCoop.CameraListener.cs
+++ b/SplitScreenCoop/SplitScreenCoop.CameraListener.cs
@@ -19,6 +19,7 @@ namespace SplitScreenCoop
             public Camera fcamera;
             public Display display;
             public RenderTexture renderTexture;
+            public RenderTexture tempTex;
             public Dictionary<string, Color> ShaderColors = new Dictionary<string, Color>();
             public Dictionary<string, Vector4> ShaderVectors = new Dictionary<string, Vector4>();
             public Dictionary<string, float> ShaderFloats = new Dictionary<string, float>();
@@ -31,7 +32,9 @@ namespace SplitScreenCoop
             public int srcHeight;
             public int dstX;
             public int dstY;
-            
+            public int dstWidth;
+            public int dstHeight;
+
 
             public bool _direct = true;
             /// <summary>
@@ -85,6 +88,7 @@ namespace SplitScreenCoop
                 }
                 display.Extras().ReinitRenderTexture();
                 renderTexture = new RenderTexture(Futile.screen.renderTexture);
+                tempTex = new RenderTexture(renderTexture);
                 SetMap(this.sourceRect, this.targetRect);
             }
             
@@ -101,6 +105,8 @@ namespace SplitScreenCoop
                 srcHeight = Mathf.FloorToInt(h * sourceRect.height);
                 dstX = Mathf.FloorToInt(w * targetRect.x);
                 dstY = Mathf.FloorToInt(h * targetRect.y);
+                dstWidth = Mathf.FloorToInt(w * targetRect.width);
+                dstHeight = Mathf.FloorToInt(h * targetRect.height);
                 this.sourceRect = sourceRect;
                 this.targetRect = targetRect;
             }
@@ -124,7 +130,16 @@ namespace SplitScreenCoop
             {
                 if (!_direct)
                 {
-                    Graphics.CopyTexture(renderTexture, 0, 0, srcX, srcY, srcWidth, srcHeight, Futile.screen.renderTexture, 0, 0, dstX, dstY);
+                    if (srcWidth != dstWidth)
+                    {
+                        var scale = sourceRect.width / targetRect.width;
+                        Graphics.Blit(renderTexture, tempTex, new Vector2(scale, scale), new Vector2(0, 0));
+                        Graphics.CopyTexture(tempTex, 0, 0, 0, 0, dstWidth, dstHeight, Futile.screen.renderTexture, 0, 0, dstX, dstY);
+                    }
+                    else
+                    {
+                        Graphics.CopyTexture(renderTexture, 0, 0, srcX, srcY, srcWidth, srcHeight, Futile.screen.renderTexture, 0, 0, dstX, dstY);
+                    }
                 }
             }
 
@@ -138,6 +153,9 @@ namespace SplitScreenCoop
                     renderTexture.Release();
                     renderTexture.DiscardContents();
                     renderTexture = null;
+                    tempTex.Release();
+                    tempTex.DiscardContents();
+                    tempTex = null;
                 }
             }
 

--- a/SplitScreenCoop/SplitScreenCoop.CoopFixes.cs
+++ b/SplitScreenCoop/SplitScreenCoop.CoopFixes.cs
@@ -225,5 +225,11 @@ namespace SplitScreenCoop
             orig(self, storyGameCharacter);
         }
 
+        // Don't move a player when they have map opened
+        private void Player_JollyInputUpdate(On.Player.orig_JollyInputUpdate orig, Player self)
+        {
+            orig(self);
+            self.standStillOnMapButton = true;
+        }
     }
 }

--- a/SplitScreenCoop/SplitScreenCoop.CoopFixes.cs
+++ b/SplitScreenCoop/SplitScreenCoop.CoopFixes.cs
@@ -166,7 +166,6 @@ namespace SplitScreenCoop
             Logger.LogInfo("RoomCamera_ChangeCameraToPlayer");
             if(self.game.cameras.Length >= self.game.Players.Count || CurrentSplitMode == SplitMode.Split4Screen) // prevent camera switching
             {
-                ToggleCameraZoom(self);
                 return;
             }
             if (cameraTarget.realizedCreature is Player player)
@@ -203,6 +202,12 @@ namespace SplitScreenCoop
             }
         }
 
+        private void Player_TriggerCameraSwitch1(On.Player.orig_TriggerCameraSwitch orig, Player self)
+        {
+            if (CurrentSplitMode == SplitMode.Split4Screen)
+                ToggleCameraZoom(self.abstractCreature.world.game.cameras[self.playerState.playerNumber]);
+            orig(self);
+        }
         // $15
         private void Player_ctor(On.Player.orig_ctor orig, Player self, AbstractCreature abstractCreature, World world)
         {

--- a/SplitScreenCoop/SplitScreenCoop.CoopFixes.cs
+++ b/SplitScreenCoop/SplitScreenCoop.CoopFixes.cs
@@ -166,6 +166,7 @@ namespace SplitScreenCoop
             Logger.LogInfo("RoomCamera_ChangeCameraToPlayer");
             if(self.game.cameras.Length >= self.game.Players.Count || CurrentSplitMode == SplitMode.Split4Screen) // prevent camera switching
             {
+                ToggleCameraZoom(self);
                 return;
             }
             if (cameraTarget.realizedCreature is Player player)

--- a/SplitScreenCoop/SplitScreenCoop.Multicamera.cs
+++ b/SplitScreenCoop/SplitScreenCoop.Multicamera.cs
@@ -328,6 +328,8 @@ namespace SplitScreenCoop
                 c.Emit(OpCodes.Ldarg_0);
                 c.EmitDelegate<Action<RoomCamera>>((rc) =>
                 {
+                    if (cameraZoomed[rc.cameraNumber])
+                        return;
                     if (CurrentSplitMode == SplitMode.SplitHorizontal)
                     {
                         float pad = rc.sSize.y / 4f;
@@ -395,7 +397,7 @@ namespace SplitScreenCoop
                     c.Emit(OpCodes.Ldarg_0); // RoomCamera
                     c.EmitDelegate<Func<float, RoomCamera, float>>((v, rc) =>
                     {
-                        if (CurrentSplitMode == SplitMode.SplitVertical || CurrentSplitMode == SplitMode.Split4Screen)
+                        if (CurrentSplitMode == SplitMode.SplitVertical || CurrentSplitMode == SplitMode.Split4Screen && !cameraZoomed[rc.cameraNumber])
                         {
                             return v - rc.sSize.x / 4f;
                         }
@@ -407,7 +409,7 @@ namespace SplitScreenCoop
                     c.Emit(OpCodes.Ldarg_0); // RoomCamera
                     c.EmitDelegate<Func<float, RoomCamera, float>>((v, rc) =>
                     {
-                        if (CurrentSplitMode == SplitMode.SplitVertical || CurrentSplitMode == SplitMode.Split4Screen)
+                        if (CurrentSplitMode == SplitMode.SplitVertical || CurrentSplitMode == SplitMode.Split4Screen && !cameraZoomed[rc.cameraNumber])
                         {
                             return v + rc.sSize.x / 4f;
                         }
@@ -419,7 +421,7 @@ namespace SplitScreenCoop
                     c.Emit(OpCodes.Ldarg_0); // RoomCamera
                     c.EmitDelegate<Func<float, RoomCamera, float>>((v, rc) =>
                     {
-                        if (CurrentSplitMode == SplitMode.SplitHorizontal || CurrentSplitMode == SplitMode.Split4Screen)
+                        if (CurrentSplitMode == SplitMode.SplitHorizontal || CurrentSplitMode == SplitMode.Split4Screen && !cameraZoomed[rc.cameraNumber])
                         {
                             return v - rc.sSize.y / 4f;
                         }
@@ -432,7 +434,7 @@ namespace SplitScreenCoop
                     c.Emit(OpCodes.Ldarg_0); // RoomCamera
                     c.EmitDelegate<Func<float, RoomCamera, float>>((v, rc) =>
                     {
-                        if (CurrentSplitMode == SplitMode.SplitHorizontal || CurrentSplitMode == SplitMode.Split4Screen)
+                        if (CurrentSplitMode == SplitMode.SplitHorizontal || CurrentSplitMode == SplitMode.Split4Screen && !cameraZoomed[rc.cameraNumber])
                         {
                             return v + rc.sSize.y / 4f;
                         }
@@ -497,7 +499,7 @@ namespace SplitScreenCoop
                         c.Emit(OpCodes.Ldarg_0); // RoomCamera
                         c.EmitDelegate<Func<float, RoomCamera, float>>((v, rc) =>
                         {
-                            if (CurrentSplitMode == SplitMode.SplitVertical || CurrentSplitMode == SplitMode.Split4Screen)
+                            if (CurrentSplitMode == SplitMode.SplitVertical || CurrentSplitMode == SplitMode.Split4Screen && !cameraZoomed[rc.cameraNumber])
                             {
                                 return v - rc.sSize.x / 4f;
                             }
@@ -509,7 +511,7 @@ namespace SplitScreenCoop
                         c.Emit(OpCodes.Ldarg_0); // RoomCamera
                         c.EmitDelegate<Func<float, RoomCamera, float>>((v, rc) =>
                         {
-                            if (CurrentSplitMode == SplitMode.SplitVertical || CurrentSplitMode == SplitMode.Split4Screen)
+                            if (CurrentSplitMode == SplitMode.SplitVertical || CurrentSplitMode == SplitMode.Split4Screen && !cameraZoomed[rc.cameraNumber])
                             {
                                 return v + rc.sSize.x / 4f;
                             }
@@ -521,7 +523,7 @@ namespace SplitScreenCoop
                         c.Emit(OpCodes.Ldarg_0); // RoomCamera
                         c.EmitDelegate<Func<float, RoomCamera, float>>((v, rc) =>
                         {
-                            if (CurrentSplitMode == SplitMode.SplitHorizontal || CurrentSplitMode == SplitMode.Split4Screen)
+                            if (CurrentSplitMode == SplitMode.SplitHorizontal || CurrentSplitMode == SplitMode.Split4Screen && !cameraZoomed[rc.cameraNumber])
                             {
                                 return v - rc.sSize.y / 4f;
                             }
@@ -534,7 +536,7 @@ namespace SplitScreenCoop
                         c.Emit(OpCodes.Ldarg_0); // RoomCamera
                         c.EmitDelegate<Func<float, RoomCamera, float>>((v, rc) =>
                         {
-                            if (CurrentSplitMode == SplitMode.SplitHorizontal || CurrentSplitMode == SplitMode.Split4Screen)
+                            if (CurrentSplitMode == SplitMode.SplitHorizontal || CurrentSplitMode == SplitMode.Split4Screen && !cameraZoomed[rc.cameraNumber])
                             {
                                 return v + rc.sSize.y / 4f;
                             }

--- a/SplitScreenCoop/SplitScreenCoop.cs
+++ b/SplitScreenCoop/SplitScreenCoop.cs
@@ -163,6 +163,8 @@ namespace SplitScreenCoop
                 On.Menu.SlugcatSelectMenu.StartGame += SlugcatSelectMenu_StartGame;
                 On.RoomCamera.ChangeCameraToPlayer += RoomCamera_ChangeCameraToPlayer;
                 IL.Player.TriggerCameraSwitch += Player_TriggerCameraSwitch;
+                On.Player.TriggerCameraSwitch += Player_TriggerCameraSwitch1;
+
                 On.Player.ctor += Player_ctor;
                 IL.HUD.HUD.InitSinglePlayerHud += InitSinglePlayerHud;
                 HookEndpointManager.Modify(typeof(JollyCoop.JollyHUD.JollyPlayerSpecificHud).GetProperty("Camera").GetGetMethod(),

--- a/SplitScreenCoop/SplitScreenCoop.cs
+++ b/SplitScreenCoop/SplitScreenCoop.cs
@@ -818,7 +818,7 @@ namespace SplitScreenCoop
                         return returnValue;
                     if (returnValue)
                     {
-                        if (followedCreature.realizedCreature == null)
+                        if (followedCreature.realizedCreature == null || followedCreature.Room == null)
                         {
                             return true;
                         }

--- a/SplitScreenCoop/SplitScreenCoop.cs
+++ b/SplitScreenCoop/SplitScreenCoop.cs
@@ -815,6 +815,10 @@ namespace SplitScreenCoop
                 c.Emit(Mono.Cecil.Cil.OpCodes.Ldarg_0);
                 c.EmitDelegate<Func<bool, JollyCoop.JollyHUD.JollyPlayerSpecificHud.JollyOffRoom, bool>>((returnValue, self) =>
                 {
+                    if (self.jollyHud.Camera == null || self.jollyHud.RealizedPlayer == null || self.jollyHud.RealizedPlayer.abstractCreature == null)
+                    {
+                        return true;
+                    }
                     // if result == true - hide slugcat icon
                     var followedCreature = self.jollyHud.Camera.followAbstractCreature;
                     if (followedCreature == self.jollyHud.RealizedPlayer.abstractCreature)

--- a/SplitScreenCoop/SplitScreenCoop.cs
+++ b/SplitScreenCoop/SplitScreenCoop.cs
@@ -604,6 +604,7 @@ namespace SplitScreenCoop
                                 fcameras[i].enabled = true;
                                 cameraListeners[i].direct = false;
                                 cameraListeners[i].SetMap(cameraSourcePositions[i], cameraTargetPositions[i]);
+                                cameraZoomed[i] = false;
                             }
                             break;
                         default:
@@ -678,11 +679,11 @@ namespace SplitScreenCoop
             // rain/karma/food
             if (cameraZoomed[self.cameraNumber])
             {
-                self.ReturnFContainer("HUD2").SetPosition(new Vector2(0, 0));
+                self.ReturnFContainer("HUD2").SetPosition(camOffsets[self.cameraNumber]);
             }
             else
             {
-                self.ReturnFContainer("HUD2").SetPosition(GetSplitScreenHudOffset(self, self.cameraNumber)); // rain/karma/food
+                self.ReturnFContainer("HUD2").SetPosition(GetSplitScreenHudOffset(self, self.cameraNumber));
             }
         }
 
@@ -739,7 +740,8 @@ namespace SplitScreenCoop
         {
             orig(self);
             var offset = GetRelativeSplitScreenOffset(self.jollyHud.Camera);
-            self.drawPos -= offset;
+            if (!cameraZoomed[self.jollyHud.Camera.cameraNumber])
+                self.drawPos -= offset;
         }
 
         public void JollyOffRoom_Update1(ILContext il)
@@ -753,7 +755,10 @@ namespace SplitScreenCoop
                 c.Emit(Mono.Cecil.Cil.OpCodes.Ldarg_0);
                 c.EmitDelegate<Func<int, JollyCoop.JollyHUD.JollyPlayerSpecificHud.JollyOffRoom, int>>((returnValue, self) =>
                 {
-                    return returnValue + (int)GetRelativeSplitScreenOffset(self.jollyHud.Camera).x;
+                    if (!cameraZoomed[self.jollyHud.Camera.cameraNumber])
+                        return returnValue + (int)GetRelativeSplitScreenOffset(self.jollyHud.Camera).x;
+                    else
+                        return returnValue;
                 });
                 c.Index++;
 
@@ -763,7 +768,10 @@ namespace SplitScreenCoop
                 c.Emit(Mono.Cecil.Cil.OpCodes.Ldarg_0);
                 c.EmitDelegate<Func<int, JollyCoop.JollyHUD.JollyPlayerSpecificHud.JollyOffRoom, int>>((returnValue, self) =>
                 {
-                    return returnValue + (int)GetRelativeSplitScreenOffset(self.jollyHud.Camera).x;
+                    if (!cameraZoomed[self.jollyHud.Camera.cameraNumber])
+                        return returnValue + (int)GetRelativeSplitScreenOffset(self.jollyHud.Camera).x;
+                    else
+                        return returnValue;
                 });
                 c.Index++;
 
@@ -773,7 +781,10 @@ namespace SplitScreenCoop
                 c.Emit(Mono.Cecil.Cil.OpCodes.Ldarg_0);
                 c.EmitDelegate<Func<int, JollyCoop.JollyHUD.JollyPlayerSpecificHud.JollyOffRoom, int>>((returnValue, self) =>
                 {
-                    return returnValue + (int)GetRelativeSplitScreenOffset(self.jollyHud.Camera).y;
+                    if (!cameraZoomed[self.jollyHud.Camera.cameraNumber])
+                        return returnValue + (int)GetRelativeSplitScreenOffset(self.jollyHud.Camera).y;
+                    else
+                        return returnValue;
                 });
                 c.Index++;
 
@@ -783,7 +794,10 @@ namespace SplitScreenCoop
                 c.Emit(Mono.Cecil.Cil.OpCodes.Ldarg_0);
                 c.EmitDelegate<Func<int, JollyCoop.JollyHUD.JollyPlayerSpecificHud.JollyOffRoom, int>>((returnValue, self) =>
                 {
-                    return returnValue + (int)GetRelativeSplitScreenOffset(self.jollyHud.Camera).y;
+                    if (!cameraZoomed[self.jollyHud.Camera.cameraNumber])
+                        return returnValue + (int)GetRelativeSplitScreenOffset(self.jollyHud.Camera).y;
+                    else
+                        return returnValue;
                 });
 
                 // Allow icons to appear when other slugcats are in the same room, but not on screen
@@ -808,8 +822,15 @@ namespace SplitScreenCoop
                         var distanceY = Math.Abs(self.playerPos.y - followedPos.y);
 
                         var magicNumber = 2.6f; // otherwise slugcat icons are sometimes placed weirdly
-                        if (distanceX > (self.jollyHud.Camera.sSize.x - magicNumber * GetRelativeSplitScreenOffset(self.jollyHud.Camera).x) ||
-                            distanceY > (self.jollyHud.Camera.sSize.y - magicNumber * GetRelativeSplitScreenOffset(self.jollyHud.Camera).y))
+                        if (cameraZoomed[self.jollyHud.Camera.cameraNumber])
+                        {
+                            if (distanceX > (self.jollyHud.Camera.sSize.x) || distanceY > (self.jollyHud.Camera.sSize.y))
+                            {
+                                returnValue = false;
+                            }
+                        }
+                        else if (distanceX > (self.jollyHud.Camera.sSize.x - magicNumber * GetRelativeSplitScreenOffset(self.jollyHud.Camera).x) ||
+                                distanceY > (self.jollyHud.Camera.sSize.y - magicNumber * GetRelativeSplitScreenOffset(self.jollyHud.Camera).y))
                         {
                             returnValue = false;
                         }
@@ -962,7 +983,8 @@ namespace SplitScreenCoop
         public Vector2 GetSplitScreenHudOffset(RoomCamera camera, int cameraNumber)
         {
             Vector2 offset = camOffsets[cameraNumber];
-            offset += GetRelativeSplitScreenOffset(camera);
+            if (!cameraZoomed[camera.cameraNumber])
+                offset += GetRelativeSplitScreenOffset(camera);
             return offset;
         }
 

--- a/SplitScreenCoop/SplitScreenCoop.cs
+++ b/SplitScreenCoop/SplitScreenCoop.cs
@@ -401,8 +401,10 @@ namespace SplitScreenCoop
                         for(int i = 1; i < ncams; i++)
                         {
                             cams[i] = new RoomCamera(self, i);
-                            if(self.session.Players.Count > i)
+                            if (i < self.session.Players.Count)
                                 cams[i].followAbstractCreature = self.session.Players[i];
+                            else
+                                cams[i].followAbstractCreature = self.session.Players[0];
                         }
                         cams[0].followAbstractCreature = self.session.Players[0];
                     }
@@ -433,10 +435,13 @@ namespace SplitScreenCoop
             if (self.cameras.Length > 1)
             {
                 Logger.LogInfo("camera2 detected");
-                for (int i = 0; i < self.session.Players.Count && i < self.cameras.Length; i++)
+                for (int i = 0; i < self.cameras.Length; i++)
                 {
-                    Logger.LogInfo($"RainWorldGame_ctor cam {self.cameras[i].cameraNumber} to p {(self.session.Players[i].state as PlayerState).playerNumber}");
-                    self.cameras[i].followAbstractCreature = self.session.Players[i];
+                    //Logger.LogInfo($"RainWorldGame_ctor cam {self.cameras[i].cameraNumber} to p {(self.session.Players[i].state as PlayerState).playerNumber}");
+                    if (i < self.session.Players.Count)
+                        self.cameras[i].followAbstractCreature = self.session.Players[i];
+                    else
+                        self.cameras[i].followAbstractCreature = self.session.Players[0];
                 }
                 SetSplitMode(alwaysSplit ? preferedSplitMode : SplitMode.NoSplit, self);
             }

--- a/SplitScreenCoop/SplitScreenCoop.cs
+++ b/SplitScreenCoop/SplitScreenCoop.cs
@@ -164,6 +164,7 @@ namespace SplitScreenCoop
                 On.RoomCamera.ChangeCameraToPlayer += RoomCamera_ChangeCameraToPlayer;
                 IL.Player.TriggerCameraSwitch += Player_TriggerCameraSwitch;
                 On.Player.TriggerCameraSwitch += Player_TriggerCameraSwitch1;
+                On.Player.JollyInputUpdate += Player_JollyInputUpdate;
 
                 On.Player.ctor += Player_ctor;
                 IL.HUD.HUD.InitSinglePlayerHud += InitSinglePlayerHud;


### PR DESCRIPTION
Tap map button to zoom out. Tap it one more time to restore original zoom
Bug fixes:
- [Fixed freezing when split mode is used with less players than intended](https://github.com/henpemaz/RemixMods/commit/1529ccd05f138fea60cf166df0c2d3b9683e4d65)
- [Don't move a player when they have map opened](https://github.com/henpemaz/RemixMods/commit/d831097ad5554e524c22bb9d0f940c1e7a86fbfc)
- [Potential freeze fix for JollyOffRoom HUD](https://github.com/henpemaz/RemixMods/commit/c897fef818f38cf1ddeda41772574bcb7305dbfd)

![4splitzoom](https://github.com/henpemaz/RemixMods/assets/5028587/7e8e832e-d76e-4347-989f-640e5695ab33)
